### PR TITLE
ci: fix pages deploy workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Deploy docs to pages
 
 on:
   push:
-    branches: [$default-branch]
+    branches: [main]
     paths:
       - 'src/**'
       - 'README.md'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A simple finite state machine library for managing predictable state transitions.
 
-## Getting Started
+## Usage
 
 ### Initialize
 


### PR DESCRIPTION
updates the pages deploy workflow. I had originally followed the instructions laid out here: https://github.com/actions/starter-workflows/blob/main/pages/static.yml

But I must have missed some sort of setup to get `$default-branch` readable.

I changed the README to trigger the pipeline naturally.